### PR TITLE
feat:Remove default value assignment for ChartType in CustomChartUpdate class

### DIFF
--- a/src/libs/LangSmith/Generated/LangSmith.Models.CustomChartUpdate.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.CustomChartUpdate.g.cs
@@ -36,7 +36,7 @@ namespace LangSmith
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("chart_type")]
         [global::System.Text.Json.Serialization.JsonConverter(typeof(global::OpenApiGenerator.JsonConverters.AnyOfJsonConverterFactory2))]
-        public global::System.AnyOf<global::LangSmith.CustomChartType?, global::LangSmith.Missing>? ChartType { get; set; } = global::LangSmith.CustomChartType.;
+        public global::System.AnyOf<global::LangSmith.CustomChartType?, global::LangSmith.Missing>? ChartType { get; set; }
 
         /// <summary>
         /// 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The `CustomChartUpdate` class now allows users to set the `ChartType` property without a default value, providing more flexibility in chart configurations.

- **Bug Fixes**
  - Removed the automatic initialization of the `ChartType` property, preventing potential issues with null or uninitialized states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->