### PR TITLE
feat:Add custom JSON converter for Unix timestamps and update TenantStats class

### DIFF
--- a/src/libs/LangSmith/Generated/JsonConverters.UnixTimestamp.g.cs
+++ b/src/libs/LangSmith/Generated/JsonConverters.UnixTimestamp.g.cs
@@ -1,0 +1,39 @@
+#nullable enable
+
+namespace OpenApiGenerator.JsonConverters
+{
+    /// <inheritdoc />
+    public class UnixTimestampJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>
+    {
+        /// <inheritdoc />
+        public override global::System.DateTimeOffset Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.Number)
+            {
+                if (reader.TryGetInt64(out long unixTimestamp))
+                {
+                    return global::System.DateTimeOffset.FromUnixTimeSeconds(unixTimestamp);
+                }
+                if (reader.TryGetInt32(out int unixTimestampInt))
+                {
+                    return global::System.DateTimeOffset.FromUnixTimeSeconds(unixTimestampInt);
+                }
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::System.DateTimeOffset value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            long unixTimestamp = value.ToUnixTimeSeconds();
+            writer.WriteNumberValue(unixTimestamp);
+        }
+    }
+}

--- a/src/libs/LangSmith/Generated/LangSmith.Models.TenantStats.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.TenantStats.g.cs
@@ -46,6 +46,13 @@ namespace LangSmith
         /// <summary>
         /// 
         /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("deployment_count")]
+        [global::System.Text.Json.Serialization.JsonRequired]
+        public required int DeploymentCount { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("dashboards_count")]
         [global::System.Text.Json.Serialization.JsonRequired]
         public required int DashboardsCount { get; set; }

--- a/src/libs/LangSmith/openapi.yaml
+++ b/src/libs/LangSmith/openapi.yaml
@@ -17322,6 +17322,7 @@ components:
         - tracer_session_count
         - repo_count
         - annotation_queue_count
+        - deployment_count
         - dashboards_count
       type: object
       properties:
@@ -17340,6 +17341,9 @@ components:
           type: integer
         annotation_queue_count:
           title: Annotation Queue Count
+          type: integer
+        deployment_count:
+          title: Deployment Count
           type: integer
         dashboards_count:
           title: Dashboards Count


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a custom JSON converter for Unix timestamps, enabling accurate serialization and deserialization of date and time data.
	- Added a new property, `DeploymentCount`, to the `TenantStats` model for enhanced tracking of tenant statistics.
	- Updated OpenAPI specification to include the `deployment_count` property, expanding the schema for deployment metrics.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->