### PR TITLE
feat:Remove new_dataset_in_playground_enabled from OrganizationConfig

### DIFF
--- a/src/libs/LangSmith/Generated/LangSmith.Models.OrganizationConfig.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.OrganizationConfig.g.cs
@@ -197,12 +197,6 @@ namespace LangSmith
         /// <summary>
         /// Default Value: false
         /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("new_dataset_in_playground_enabled")]
-        public bool? NewDatasetInPlaygroundEnabled { get; set; }
-
-        /// <summary>
-        /// Default Value: false
-        /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("langsmith_alerts_poc_enabled")]
         public bool? LangsmithAlertsPocEnabled { get; set; }
 
@@ -308,9 +302,6 @@ namespace LangSmith
         /// <param name="langgraphRemoteReconcilerEnabled">
         /// Default Value: false
         /// </param>
-        /// <param name="newDatasetInPlaygroundEnabled">
-        /// Default Value: false
-        /// </param>
         /// <param name="langsmithAlertsPocEnabled">
         /// Default Value: false
         /// </param>
@@ -352,7 +343,6 @@ namespace LangSmith
             bool? demoLgpNewGraphEnabled,
             int? datadogRumSessionSampleRate,
             bool? langgraphRemoteReconcilerEnabled,
-            bool? newDatasetInPlaygroundEnabled,
             bool? langsmithAlertsPocEnabled,
             bool? tenantSkipTopkFacets)
         {
@@ -387,7 +377,6 @@ namespace LangSmith
             this.DemoLgpNewGraphEnabled = demoLgpNewGraphEnabled;
             this.DatadogRumSessionSampleRate = datadogRumSessionSampleRate;
             this.LanggraphRemoteReconcilerEnabled = langgraphRemoteReconcilerEnabled;
-            this.NewDatasetInPlaygroundEnabled = newDatasetInPlaygroundEnabled;
             this.LangsmithAlertsPocEnabled = langsmithAlertsPocEnabled;
             this.TenantSkipTopkFacets = tenantSkipTopkFacets;
         }

--- a/src/libs/LangSmith/openapi.yaml
+++ b/src/libs/LangSmith/openapi.yaml
@@ -17609,10 +17609,6 @@ components:
           title: Langgraph Remote Reconciler Enabled
           type: boolean
           default: false
-        new_dataset_in_playground_enabled:
-          title: New Dataset In Playground Enabled
-          type: boolean
-          default: false
         langsmith_alerts_poc_enabled:
           title: Langsmith Alerts Poc Enabled
           type: boolean


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Removed the option to create a new dataset in the playground, as this functionality has been deprecated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->