### PR TITLE
feat:Add optional expires_at field to API key schemas in OpenAPI specification

### DIFF
--- a/src/libs/LangSmith/Generated/LangSmith.ApiKeyClient.GenerateApiKey.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.ApiKeyClient.GenerateApiKey.g.cs
@@ -213,17 +213,20 @@ namespace LangSmith
         /// <param name="readOnly">
         /// Default Value: false
         /// </param>
+        /// <param name="expiresAt"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         public async global::System.Threading.Tasks.Task<global::LangSmith.APIKeyCreateResponse> GenerateApiKeyAsync(
             string? description = default,
             bool? readOnly = default,
+            global::System.DateTime? expiresAt = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             var __request = new global::LangSmith.APIKeyCreateRequest
             {
                 Description = description,
                 ReadOnly = readOnly,
+                ExpiresAt = expiresAt,
             };
 
             return await GenerateApiKeyAsync(

--- a/src/libs/LangSmith/Generated/LangSmith.ApiKeyClient.GeneratePersonalAccessToken.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.ApiKeyClient.GeneratePersonalAccessToken.g.cs
@@ -213,17 +213,20 @@ namespace LangSmith
         /// <param name="readOnly">
         /// Default Value: false
         /// </param>
+        /// <param name="expiresAt"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         public async global::System.Threading.Tasks.Task<global::LangSmith.APIKeyCreateResponse> GeneratePersonalAccessTokenAsync(
             string? description = default,
             bool? readOnly = default,
+            global::System.DateTime? expiresAt = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             var __request = new global::LangSmith.APIKeyCreateRequest
             {
                 Description = description,
                 ReadOnly = readOnly,
+                ExpiresAt = expiresAt,
             };
 
             return await GeneratePersonalAccessTokenAsync(

--- a/src/libs/LangSmith/Generated/LangSmith.IApiKeyClient.GenerateApiKey.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.IApiKeyClient.GenerateApiKey.g.cs
@@ -25,11 +25,13 @@ namespace LangSmith
         /// <param name="readOnly">
         /// Default Value: false
         /// </param>
+        /// <param name="expiresAt"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         global::System.Threading.Tasks.Task<global::LangSmith.APIKeyCreateResponse> GenerateApiKeyAsync(
             string? description = default,
             bool? readOnly = default,
+            global::System.DateTime? expiresAt = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }
 }

--- a/src/libs/LangSmith/Generated/LangSmith.IApiKeyClient.GeneratePersonalAccessToken.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.IApiKeyClient.GeneratePersonalAccessToken.g.cs
@@ -25,11 +25,13 @@ namespace LangSmith
         /// <param name="readOnly">
         /// Default Value: false
         /// </param>
+        /// <param name="expiresAt"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         global::System.Threading.Tasks.Task<global::LangSmith.APIKeyCreateResponse> GeneratePersonalAccessTokenAsync(
             string? description = default,
             bool? readOnly = default,
+            global::System.DateTime? expiresAt = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }
 }

--- a/src/libs/LangSmith/Generated/LangSmith.JsonSerializerContextTypes.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.JsonSerializerContextTypes.g.cs
@@ -126,11 +126,11 @@ namespace LangSmith
         /// <summary>
         /// 
         /// </summary>
-        public global::LangSmith.APIKeyCreateResponse? Type25 { get; set; }
+        public global::System.DateTime? Type25 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.DateTime? Type26 { get; set; }
+        public global::LangSmith.APIKeyCreateResponse? Type26 { get; set; }
         /// <summary>
         /// 
         /// </summary>

--- a/src/libs/LangSmith/Generated/LangSmith.Models.APIKeyCreateRequest.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.APIKeyCreateRequest.g.cs
@@ -4,7 +4,8 @@
 namespace LangSmith
 {
     /// <summary>
-    /// API key POST schema.
+    /// API key POST schema.<br/>
+    /// expires_at: Optional datetime when the API key will expire.
     /// </summary>
     public sealed partial class APIKeyCreateRequest
     {
@@ -21,6 +22,12 @@ namespace LangSmith
         public bool? ReadOnly { get; set; }
 
         /// <summary>
+        /// 
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("expires_at")]
+        public global::System.DateTime? ExpiresAt { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -35,15 +42,18 @@ namespace LangSmith
         /// <param name="readOnly">
         /// Default Value: false
         /// </param>
+        /// <param name="expiresAt"></param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
         public APIKeyCreateRequest(
             string? description,
-            bool? readOnly)
+            bool? readOnly,
+            global::System.DateTime? expiresAt)
         {
             this.Description = description;
             this.ReadOnly = readOnly;
+            this.ExpiresAt = expiresAt;
         }
 
         /// <summary>

--- a/src/libs/LangSmith/Generated/LangSmith.Models.APIKeyCreateResponse.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.APIKeyCreateResponse.g.cs
@@ -50,6 +50,12 @@ namespace LangSmith
         /// <summary>
         /// 
         /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("expires_at")]
+        public global::System.DateTime? ExpiresAt { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("key")]
         [global::System.Text.Json.Serialization.JsonRequired]
         public required string Key { get; set; }
@@ -71,6 +77,7 @@ namespace LangSmith
         /// Default Value: false
         /// </param>
         /// <param name="lastUsedAt"></param>
+        /// <param name="expiresAt"></param>
         /// <param name="key"></param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
@@ -82,7 +89,8 @@ namespace LangSmith
             string key,
             global::System.DateTime? createdAt,
             bool? readOnly,
-            global::System.DateTime? lastUsedAt)
+            global::System.DateTime? lastUsedAt,
+            global::System.DateTime? expiresAt)
         {
             this.Id = id;
             this.ShortKey = shortKey ?? throw new global::System.ArgumentNullException(nameof(shortKey));
@@ -91,6 +99,7 @@ namespace LangSmith
             this.CreatedAt = createdAt;
             this.ReadOnly = readOnly;
             this.LastUsedAt = lastUsedAt;
+            this.ExpiresAt = expiresAt;
         }
 
         /// <summary>

--- a/src/libs/LangSmith/Generated/LangSmith.Models.APIKeyGetResponse.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.APIKeyGetResponse.g.cs
@@ -48,6 +48,12 @@ namespace LangSmith
         public global::System.DateTime? LastUsedAt { get; set; }
 
         /// <summary>
+        /// 
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("expires_at")]
+        public global::System.DateTime? ExpiresAt { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -64,6 +70,7 @@ namespace LangSmith
         /// Default Value: false
         /// </param>
         /// <param name="lastUsedAt"></param>
+        /// <param name="expiresAt"></param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
@@ -73,7 +80,8 @@ namespace LangSmith
             string description,
             global::System.DateTime? createdAt,
             bool? readOnly,
-            global::System.DateTime? lastUsedAt)
+            global::System.DateTime? lastUsedAt,
+            global::System.DateTime? expiresAt)
         {
             this.Id = id;
             this.ShortKey = shortKey ?? throw new global::System.ArgumentNullException(nameof(shortKey));
@@ -81,6 +89,7 @@ namespace LangSmith
             this.CreatedAt = createdAt;
             this.ReadOnly = readOnly;
             this.LastUsedAt = lastUsedAt;
+            this.ExpiresAt = expiresAt;
         }
 
         /// <summary>

--- a/src/libs/LangSmith/openapi.yaml
+++ b/src/libs/LangSmith/openapi.yaml
@@ -12817,7 +12817,12 @@ components:
           title: Read Only
           type: boolean
           default: false
-      description: API key POST schema.
+        expires_at:
+          title: Expires At
+          type: string
+          format: date-time
+          nullable: true
+      description: "API key POST schema.\n\nexpires_at: Optional datetime when the API key will expire."
     APIKeyCreateResponse:
       title: APIKeyCreateResponse
       required:
@@ -12848,6 +12853,11 @@ components:
           default: false
         last_used_at:
           title: Last Used At
+          type: string
+          format: date-time
+          nullable: true
+        expires_at:
+          title: Expires At
           type: string
           format: date-time
           nullable: true
@@ -12884,6 +12894,11 @@ components:
           default: false
         last_used_at:
           title: Last Used At
+          type: string
+          format: date-time
+          nullable: true
+        expires_at:
+          title: Expires At
           type: string
           format: date-time
           nullable: true


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying an optional expiration date and time when creating API keys.
  * API key details now display the expiration date and time if set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->