### PR TITLE
feat:Add endpoints for organization personal access tokens and update schema

### DIFF
--- a/src/libs/LangSmith/Generated/LangSmith.IOrgsClient.CreateOrgPersonalAccessToken.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.IOrgsClient.CreateOrgPersonalAccessToken.g.cs
@@ -1,0 +1,37 @@
+#nullable enable
+
+namespace LangSmith
+{
+    public partial interface IOrgsClient
+    {
+        /// <summary>
+        /// Create Org Personal Access Token
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="cancellationToken">The token to cancel the operation with</param>
+        /// <exception cref="global::LangSmith.ApiException"></exception>
+        global::System.Threading.Tasks.Task<global::LangSmith.APIKeyCreateResponse> CreateOrgPersonalAccessTokenAsync(
+            global::LangSmith.APIKeyCreateRequest request,
+            global::System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Create Org Personal Access Token
+        /// </summary>
+        /// <param name="description">
+        /// Default Value: Default API key
+        /// </param>
+        /// <param name="readOnly">
+        /// Default Value: false
+        /// </param>
+        /// <param name="expiresAt"></param>
+        /// <param name="workspaces"></param>
+        /// <param name="cancellationToken">The token to cancel the operation with</param>
+        /// <exception cref="global::System.InvalidOperationException"></exception>
+        global::System.Threading.Tasks.Task<global::LangSmith.APIKeyCreateResponse> CreateOrgPersonalAccessTokenAsync(
+            string? description = default,
+            bool? readOnly = default,
+            global::System.DateTime? expiresAt = default,
+            global::System.Collections.Generic.IList<global::System.Guid>? workspaces = default,
+            global::System.Threading.CancellationToken cancellationToken = default);
+    }
+}

--- a/src/libs/LangSmith/Generated/LangSmith.IOrgsClient.DeleteOrgPersonalAccessToken.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.IOrgsClient.DeleteOrgPersonalAccessToken.g.cs
@@ -1,0 +1,17 @@
+#nullable enable
+
+namespace LangSmith
+{
+    public partial interface IOrgsClient
+    {
+        /// <summary>
+        /// Delete Org Personal Access Token
+        /// </summary>
+        /// <param name="patId"></param>
+        /// <param name="cancellationToken">The token to cancel the operation with</param>
+        /// <exception cref="global::LangSmith.ApiException"></exception>
+        global::System.Threading.Tasks.Task<global::LangSmith.APIKeyGetResponse> DeleteOrgPersonalAccessTokenAsync(
+            global::System.Guid patId,
+            global::System.Threading.CancellationToken cancellationToken = default);
+    }
+}

--- a/src/libs/LangSmith/Generated/LangSmith.IOrgsClient.ListOrgPersonalAccessTokens.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.IOrgsClient.ListOrgPersonalAccessTokens.g.cs
@@ -1,0 +1,15 @@
+#nullable enable
+
+namespace LangSmith
+{
+    public partial interface IOrgsClient
+    {
+        /// <summary>
+        /// List Org Personal Access Tokens
+        /// </summary>
+        /// <param name="cancellationToken">The token to cancel the operation with</param>
+        /// <exception cref="global::LangSmith.ApiException"></exception>
+        global::System.Threading.Tasks.Task<global::System.Collections.Generic.IList<global::LangSmith.APIKeyGetResponse>> ListOrgPersonalAccessTokensAsync(
+            global::System.Threading.CancellationToken cancellationToken = default);
+    }
+}

--- a/src/libs/LangSmith/Generated/LangSmith.Models.OrganizationConfig.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.OrganizationConfig.g.cs
@@ -263,12 +263,6 @@ namespace LangSmith
         /// <summary>
         /// Default Value: false
         /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("enable_tracing_project_redesign")]
-        public bool? EnableTracingProjectRedesign { get; set; }
-
-        /// <summary>
-        /// Default Value: false
-        /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("org_scoped_service_accounts_enabled")]
         public bool? OrgScopedServiceAccountsEnabled { get; set; }
 
@@ -407,9 +401,6 @@ namespace LangSmith
         /// <param name="newRuleEvaluatorCreationVersion">
         /// Default Value: 2
         /// </param>
-        /// <param name="enableTracingProjectRedesign">
-        /// Default Value: false
-        /// </param>
         /// <param name="orgScopedServiceAccountsEnabled">
         /// Default Value: false
         /// </param>
@@ -462,7 +453,6 @@ namespace LangSmith
             bool? enableMonthlyUsageCharts,
             bool? enableLgpMetricsCharts,
             int? newRuleEvaluatorCreationVersion,
-            bool? enableTracingProjectRedesign,
             bool? orgScopedServiceAccountsEnabled,
             bool? enableLgpListenersPage)
         {
@@ -508,7 +498,6 @@ namespace LangSmith
             this.EnableMonthlyUsageCharts = enableMonthlyUsageCharts;
             this.EnableLgpMetricsCharts = enableLgpMetricsCharts;
             this.NewRuleEvaluatorCreationVersion = newRuleEvaluatorCreationVersion;
-            this.EnableTracingProjectRedesign = enableTracingProjectRedesign;
             this.OrgScopedServiceAccountsEnabled = orgScopedServiceAccountsEnabled;
             this.EnableLgpListenersPage = enableLgpListenersPage;
         }

--- a/src/libs/LangSmith/Generated/LangSmith.OrgsClient.CreateOrgPersonalAccessToken.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.OrgsClient.CreateOrgPersonalAccessToken.g.cs
@@ -1,0 +1,238 @@
+
+#nullable enable
+
+namespace LangSmith
+{
+    public partial class OrgsClient
+    {
+        partial void PrepareCreateOrgPersonalAccessTokenArguments(
+            global::System.Net.Http.HttpClient httpClient,
+            global::LangSmith.APIKeyCreateRequest request);
+        partial void PrepareCreateOrgPersonalAccessTokenRequest(
+            global::System.Net.Http.HttpClient httpClient,
+            global::System.Net.Http.HttpRequestMessage httpRequestMessage,
+            global::LangSmith.APIKeyCreateRequest request);
+        partial void ProcessCreateOrgPersonalAccessTokenResponse(
+            global::System.Net.Http.HttpClient httpClient,
+            global::System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+        partial void ProcessCreateOrgPersonalAccessTokenResponseContent(
+            global::System.Net.Http.HttpClient httpClient,
+            global::System.Net.Http.HttpResponseMessage httpResponseMessage,
+            ref string content);
+
+        /// <summary>
+        /// Create Org Personal Access Token
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="cancellationToken">The token to cancel the operation with</param>
+        /// <exception cref="global::LangSmith.ApiException"></exception>
+        public async global::System.Threading.Tasks.Task<global::LangSmith.APIKeyCreateResponse> CreateOrgPersonalAccessTokenAsync(
+            global::LangSmith.APIKeyCreateRequest request,
+            global::System.Threading.CancellationToken cancellationToken = default)
+        {
+            request = request ?? throw new global::System.ArgumentNullException(nameof(request));
+
+            PrepareArguments(
+                client: HttpClient);
+            PrepareCreateOrgPersonalAccessTokenArguments(
+                httpClient: HttpClient,
+                request: request);
+
+            var __pathBuilder = new global::LangSmith.PathBuilder(
+                path: "/api/v1/orgs/current/personal-access-tokens",
+                baseUri: HttpClient.BaseAddress); 
+            var __path = __pathBuilder.ToString();
+            using var __httpRequest = new global::System.Net.Http.HttpRequestMessage(
+                method: global::System.Net.Http.HttpMethod.Post,
+                requestUri: new global::System.Uri(__path, global::System.UriKind.RelativeOrAbsolute));
+#if NET6_0_OR_GREATER
+            __httpRequest.Version = global::System.Net.HttpVersion.Version11;
+            __httpRequest.VersionPolicy = global::System.Net.Http.HttpVersionPolicy.RequestVersionOrHigher;
+#endif
+
+            foreach (var __authorization in Authorizations)
+            {
+                if (__authorization.Type == "Http" ||
+                    __authorization.Type == "OAuth2")
+                {
+                    __httpRequest.Headers.Authorization = new global::System.Net.Http.Headers.AuthenticationHeaderValue(
+                        scheme: __authorization.Name,
+                        parameter: __authorization.Value);
+                }
+                else if (__authorization.Type == "ApiKey" &&
+                         __authorization.Location == "Header")
+                {
+                    __httpRequest.Headers.Add(__authorization.Name, __authorization.Value);
+                }
+            }
+            var __httpRequestContentBody = request.ToJson(JsonSerializerContext);
+            var __httpRequestContent = new global::System.Net.Http.StringContent(
+                content: __httpRequestContentBody,
+                encoding: global::System.Text.Encoding.UTF8,
+                mediaType: "application/json");
+            __httpRequest.Content = __httpRequestContent;
+
+            PrepareRequest(
+                client: HttpClient,
+                request: __httpRequest);
+            PrepareCreateOrgPersonalAccessTokenRequest(
+                httpClient: HttpClient,
+                httpRequestMessage: __httpRequest,
+                request: request);
+
+            using var __response = await HttpClient.SendAsync(
+                request: __httpRequest,
+                completionOption: global::System.Net.Http.HttpCompletionOption.ResponseContentRead,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            ProcessResponse(
+                client: HttpClient,
+                response: __response);
+            ProcessCreateOrgPersonalAccessTokenResponse(
+                httpClient: HttpClient,
+                httpResponseMessage: __response);
+            // Validation Error
+            if ((int)__response.StatusCode == 422)
+            {
+                string? __content_422 = null;
+                global::System.Exception? __exception_422 = null;
+                global::LangSmith.HTTPValidationError? __value_422 = null;
+                try
+                {
+                    if (ReadResponseAsString)
+                    {
+                        __content_422 = await __response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                        __value_422 = global::LangSmith.HTTPValidationError.FromJson(__content_422, JsonSerializerContext);
+                    }
+                    else
+                    {
+                        var __contentStream_422 = await __response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                        __value_422 = await global::LangSmith.HTTPValidationError.FromJsonStreamAsync(__contentStream_422, JsonSerializerContext).ConfigureAwait(false);
+                    }
+                }
+                catch (global::System.Exception __ex)
+                {
+                    __exception_422 = __ex;
+                }
+
+                throw new global::LangSmith.ApiException<global::LangSmith.HTTPValidationError>(
+                    message: __content_422 ?? __response.ReasonPhrase ?? string.Empty,
+                    innerException: __exception_422,
+                    statusCode: __response.StatusCode)
+                {
+                    ResponseBody = __content_422,
+                    ResponseObject = __value_422,
+                    ResponseHeaders = global::System.Linq.Enumerable.ToDictionary(
+                        __response.Headers,
+                        h => h.Key,
+                        h => h.Value),
+                };
+            }
+
+            if (ReadResponseAsString)
+            {
+                var __content = await __response.Content.ReadAsStringAsync(
+#if NET5_0_OR_GREATER
+                    cancellationToken
+#endif
+                ).ConfigureAwait(false);
+
+                ProcessResponseContent(
+                    client: HttpClient,
+                    response: __response,
+                    content: ref __content);
+                ProcessCreateOrgPersonalAccessTokenResponseContent(
+                    httpClient: HttpClient,
+                    httpResponseMessage: __response,
+                    content: ref __content);
+
+                try
+                {
+                    __response.EnsureSuccessStatusCode();
+
+                    return
+                        global::LangSmith.APIKeyCreateResponse.FromJson(__content, JsonSerializerContext) ??
+                        throw new global::System.InvalidOperationException($"Response deserialization failed for \"{__content}\" ");
+                }
+                catch (global::System.Exception __ex)
+                {
+                    throw new global::LangSmith.ApiException(
+                        message: __content ?? __response.ReasonPhrase ?? string.Empty,
+                        innerException: __ex,
+                        statusCode: __response.StatusCode)
+                    {
+                        ResponseBody = __content,
+                        ResponseHeaders = global::System.Linq.Enumerable.ToDictionary(
+                            __response.Headers,
+                            h => h.Key,
+                            h => h.Value),
+                    };
+                }
+            }
+            else
+            {
+                try
+                {
+                    __response.EnsureSuccessStatusCode();
+
+                    using var __content = await __response.Content.ReadAsStreamAsync(
+#if NET5_0_OR_GREATER
+                        cancellationToken
+#endif
+                    ).ConfigureAwait(false);
+
+                    return
+                        await global::LangSmith.APIKeyCreateResponse.FromJsonStreamAsync(__content, JsonSerializerContext).ConfigureAwait(false) ??
+                        throw new global::System.InvalidOperationException("Response deserialization failed.");
+                }
+                catch (global::System.Exception __ex)
+                {
+                    throw new global::LangSmith.ApiException(
+                        message: __response.ReasonPhrase ?? string.Empty,
+                        innerException: __ex,
+                        statusCode: __response.StatusCode)
+                    {
+                        ResponseHeaders = global::System.Linq.Enumerable.ToDictionary(
+                            __response.Headers,
+                            h => h.Key,
+                            h => h.Value),
+                    };
+                }
+            }
+        }
+
+        /// <summary>
+        /// Create Org Personal Access Token
+        /// </summary>
+        /// <param name="description">
+        /// Default Value: Default API key
+        /// </param>
+        /// <param name="readOnly">
+        /// Default Value: false
+        /// </param>
+        /// <param name="expiresAt"></param>
+        /// <param name="workspaces"></param>
+        /// <param name="cancellationToken">The token to cancel the operation with</param>
+        /// <exception cref="global::System.InvalidOperationException"></exception>
+        public async global::System.Threading.Tasks.Task<global::LangSmith.APIKeyCreateResponse> CreateOrgPersonalAccessTokenAsync(
+            string? description = default,
+            bool? readOnly = default,
+            global::System.DateTime? expiresAt = default,
+            global::System.Collections.Generic.IList<global::System.Guid>? workspaces = default,
+            global::System.Threading.CancellationToken cancellationToken = default)
+        {
+            var __request = new global::LangSmith.APIKeyCreateRequest
+            {
+                Description = description,
+                ReadOnly = readOnly,
+                ExpiresAt = expiresAt,
+                Workspaces = workspaces,
+            };
+
+            return await CreateOrgPersonalAccessTokenAsync(
+                request: __request,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/libs/LangSmith/Generated/LangSmith.OrgsClient.DeleteOrgPersonalAccessToken.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.OrgsClient.DeleteOrgPersonalAccessToken.g.cs
@@ -1,0 +1,197 @@
+
+#nullable enable
+
+namespace LangSmith
+{
+    public partial class OrgsClient
+    {
+        partial void PrepareDeleteOrgPersonalAccessTokenArguments(
+            global::System.Net.Http.HttpClient httpClient,
+            ref global::System.Guid patId);
+        partial void PrepareDeleteOrgPersonalAccessTokenRequest(
+            global::System.Net.Http.HttpClient httpClient,
+            global::System.Net.Http.HttpRequestMessage httpRequestMessage,
+            global::System.Guid patId);
+        partial void ProcessDeleteOrgPersonalAccessTokenResponse(
+            global::System.Net.Http.HttpClient httpClient,
+            global::System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+        partial void ProcessDeleteOrgPersonalAccessTokenResponseContent(
+            global::System.Net.Http.HttpClient httpClient,
+            global::System.Net.Http.HttpResponseMessage httpResponseMessage,
+            ref string content);
+
+        /// <summary>
+        /// Delete Org Personal Access Token
+        /// </summary>
+        /// <param name="patId"></param>
+        /// <param name="cancellationToken">The token to cancel the operation with</param>
+        /// <exception cref="global::LangSmith.ApiException"></exception>
+        public async global::System.Threading.Tasks.Task<global::LangSmith.APIKeyGetResponse> DeleteOrgPersonalAccessTokenAsync(
+            global::System.Guid patId,
+            global::System.Threading.CancellationToken cancellationToken = default)
+        {
+            PrepareArguments(
+                client: HttpClient);
+            PrepareDeleteOrgPersonalAccessTokenArguments(
+                httpClient: HttpClient,
+                patId: ref patId);
+
+            var __pathBuilder = new global::LangSmith.PathBuilder(
+                path: $"/api/v1/orgs/current/personal-access-tokens/{patId}",
+                baseUri: HttpClient.BaseAddress); 
+            var __path = __pathBuilder.ToString();
+            using var __httpRequest = new global::System.Net.Http.HttpRequestMessage(
+                method: global::System.Net.Http.HttpMethod.Delete,
+                requestUri: new global::System.Uri(__path, global::System.UriKind.RelativeOrAbsolute));
+#if NET6_0_OR_GREATER
+            __httpRequest.Version = global::System.Net.HttpVersion.Version11;
+            __httpRequest.VersionPolicy = global::System.Net.Http.HttpVersionPolicy.RequestVersionOrHigher;
+#endif
+
+            foreach (var __authorization in Authorizations)
+            {
+                if (__authorization.Type == "Http" ||
+                    __authorization.Type == "OAuth2")
+                {
+                    __httpRequest.Headers.Authorization = new global::System.Net.Http.Headers.AuthenticationHeaderValue(
+                        scheme: __authorization.Name,
+                        parameter: __authorization.Value);
+                }
+                else if (__authorization.Type == "ApiKey" &&
+                         __authorization.Location == "Header")
+                {
+                    __httpRequest.Headers.Add(__authorization.Name, __authorization.Value);
+                }
+            }
+
+            PrepareRequest(
+                client: HttpClient,
+                request: __httpRequest);
+            PrepareDeleteOrgPersonalAccessTokenRequest(
+                httpClient: HttpClient,
+                httpRequestMessage: __httpRequest,
+                patId: patId);
+
+            using var __response = await HttpClient.SendAsync(
+                request: __httpRequest,
+                completionOption: global::System.Net.Http.HttpCompletionOption.ResponseContentRead,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            ProcessResponse(
+                client: HttpClient,
+                response: __response);
+            ProcessDeleteOrgPersonalAccessTokenResponse(
+                httpClient: HttpClient,
+                httpResponseMessage: __response);
+            // Validation Error
+            if ((int)__response.StatusCode == 422)
+            {
+                string? __content_422 = null;
+                global::System.Exception? __exception_422 = null;
+                global::LangSmith.HTTPValidationError? __value_422 = null;
+                try
+                {
+                    if (ReadResponseAsString)
+                    {
+                        __content_422 = await __response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                        __value_422 = global::LangSmith.HTTPValidationError.FromJson(__content_422, JsonSerializerContext);
+                    }
+                    else
+                    {
+                        var __contentStream_422 = await __response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                        __value_422 = await global::LangSmith.HTTPValidationError.FromJsonStreamAsync(__contentStream_422, JsonSerializerContext).ConfigureAwait(false);
+                    }
+                }
+                catch (global::System.Exception __ex)
+                {
+                    __exception_422 = __ex;
+                }
+
+                throw new global::LangSmith.ApiException<global::LangSmith.HTTPValidationError>(
+                    message: __content_422 ?? __response.ReasonPhrase ?? string.Empty,
+                    innerException: __exception_422,
+                    statusCode: __response.StatusCode)
+                {
+                    ResponseBody = __content_422,
+                    ResponseObject = __value_422,
+                    ResponseHeaders = global::System.Linq.Enumerable.ToDictionary(
+                        __response.Headers,
+                        h => h.Key,
+                        h => h.Value),
+                };
+            }
+
+            if (ReadResponseAsString)
+            {
+                var __content = await __response.Content.ReadAsStringAsync(
+#if NET5_0_OR_GREATER
+                    cancellationToken
+#endif
+                ).ConfigureAwait(false);
+
+                ProcessResponseContent(
+                    client: HttpClient,
+                    response: __response,
+                    content: ref __content);
+                ProcessDeleteOrgPersonalAccessTokenResponseContent(
+                    httpClient: HttpClient,
+                    httpResponseMessage: __response,
+                    content: ref __content);
+
+                try
+                {
+                    __response.EnsureSuccessStatusCode();
+
+                    return
+                        global::LangSmith.APIKeyGetResponse.FromJson(__content, JsonSerializerContext) ??
+                        throw new global::System.InvalidOperationException($"Response deserialization failed for \"{__content}\" ");
+                }
+                catch (global::System.Exception __ex)
+                {
+                    throw new global::LangSmith.ApiException(
+                        message: __content ?? __response.ReasonPhrase ?? string.Empty,
+                        innerException: __ex,
+                        statusCode: __response.StatusCode)
+                    {
+                        ResponseBody = __content,
+                        ResponseHeaders = global::System.Linq.Enumerable.ToDictionary(
+                            __response.Headers,
+                            h => h.Key,
+                            h => h.Value),
+                    };
+                }
+            }
+            else
+            {
+                try
+                {
+                    __response.EnsureSuccessStatusCode();
+
+                    using var __content = await __response.Content.ReadAsStreamAsync(
+#if NET5_0_OR_GREATER
+                        cancellationToken
+#endif
+                    ).ConfigureAwait(false);
+
+                    return
+                        await global::LangSmith.APIKeyGetResponse.FromJsonStreamAsync(__content, JsonSerializerContext).ConfigureAwait(false) ??
+                        throw new global::System.InvalidOperationException("Response deserialization failed.");
+                }
+                catch (global::System.Exception __ex)
+                {
+                    throw new global::LangSmith.ApiException(
+                        message: __response.ReasonPhrase ?? string.Empty,
+                        innerException: __ex,
+                        statusCode: __response.StatusCode)
+                    {
+                        ResponseHeaders = global::System.Linq.Enumerable.ToDictionary(
+                            __response.Headers,
+                            h => h.Key,
+                            h => h.Value),
+                    };
+                }
+            }
+        }
+    }
+}

--- a/src/libs/LangSmith/Generated/LangSmith.OrgsClient.ListOrgPersonalAccessTokens.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.OrgsClient.ListOrgPersonalAccessTokens.g.cs
@@ -1,0 +1,154 @@
+
+#nullable enable
+
+namespace LangSmith
+{
+    public partial class OrgsClient
+    {
+        partial void PrepareListOrgPersonalAccessTokensArguments(
+            global::System.Net.Http.HttpClient httpClient);
+        partial void PrepareListOrgPersonalAccessTokensRequest(
+            global::System.Net.Http.HttpClient httpClient,
+            global::System.Net.Http.HttpRequestMessage httpRequestMessage);
+        partial void ProcessListOrgPersonalAccessTokensResponse(
+            global::System.Net.Http.HttpClient httpClient,
+            global::System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+        partial void ProcessListOrgPersonalAccessTokensResponseContent(
+            global::System.Net.Http.HttpClient httpClient,
+            global::System.Net.Http.HttpResponseMessage httpResponseMessage,
+            ref string content);
+
+        /// <summary>
+        /// List Org Personal Access Tokens
+        /// </summary>
+        /// <param name="cancellationToken">The token to cancel the operation with</param>
+        /// <exception cref="global::LangSmith.ApiException"></exception>
+        public async global::System.Threading.Tasks.Task<global::System.Collections.Generic.IList<global::LangSmith.APIKeyGetResponse>> ListOrgPersonalAccessTokensAsync(
+            global::System.Threading.CancellationToken cancellationToken = default)
+        {
+            PrepareArguments(
+                client: HttpClient);
+            PrepareListOrgPersonalAccessTokensArguments(
+                httpClient: HttpClient);
+
+            var __pathBuilder = new global::LangSmith.PathBuilder(
+                path: "/api/v1/orgs/current/personal-access-tokens",
+                baseUri: HttpClient.BaseAddress); 
+            var __path = __pathBuilder.ToString();
+            using var __httpRequest = new global::System.Net.Http.HttpRequestMessage(
+                method: global::System.Net.Http.HttpMethod.Get,
+                requestUri: new global::System.Uri(__path, global::System.UriKind.RelativeOrAbsolute));
+#if NET6_0_OR_GREATER
+            __httpRequest.Version = global::System.Net.HttpVersion.Version11;
+            __httpRequest.VersionPolicy = global::System.Net.Http.HttpVersionPolicy.RequestVersionOrHigher;
+#endif
+
+            foreach (var __authorization in Authorizations)
+            {
+                if (__authorization.Type == "Http" ||
+                    __authorization.Type == "OAuth2")
+                {
+                    __httpRequest.Headers.Authorization = new global::System.Net.Http.Headers.AuthenticationHeaderValue(
+                        scheme: __authorization.Name,
+                        parameter: __authorization.Value);
+                }
+                else if (__authorization.Type == "ApiKey" &&
+                         __authorization.Location == "Header")
+                {
+                    __httpRequest.Headers.Add(__authorization.Name, __authorization.Value);
+                }
+            }
+
+            PrepareRequest(
+                client: HttpClient,
+                request: __httpRequest);
+            PrepareListOrgPersonalAccessTokensRequest(
+                httpClient: HttpClient,
+                httpRequestMessage: __httpRequest);
+
+            using var __response = await HttpClient.SendAsync(
+                request: __httpRequest,
+                completionOption: global::System.Net.Http.HttpCompletionOption.ResponseContentRead,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            ProcessResponse(
+                client: HttpClient,
+                response: __response);
+            ProcessListOrgPersonalAccessTokensResponse(
+                httpClient: HttpClient,
+                httpResponseMessage: __response);
+
+            if (ReadResponseAsString)
+            {
+                var __content = await __response.Content.ReadAsStringAsync(
+#if NET5_0_OR_GREATER
+                    cancellationToken
+#endif
+                ).ConfigureAwait(false);
+
+                ProcessResponseContent(
+                    client: HttpClient,
+                    response: __response,
+                    content: ref __content);
+                ProcessListOrgPersonalAccessTokensResponseContent(
+                    httpClient: HttpClient,
+                    httpResponseMessage: __response,
+                    content: ref __content);
+
+                try
+                {
+                    __response.EnsureSuccessStatusCode();
+
+                    return
+                        global::System.Text.Json.JsonSerializer.Deserialize(__content, typeof(global::System.Collections.Generic.IList<global::LangSmith.APIKeyGetResponse>), JsonSerializerContext) as global::System.Collections.Generic.IList<global::LangSmith.APIKeyGetResponse> ??
+                        throw new global::System.InvalidOperationException($"Response deserialization failed for \"{__content}\" ");
+                }
+                catch (global::System.Exception __ex)
+                {
+                    throw new global::LangSmith.ApiException(
+                        message: __content ?? __response.ReasonPhrase ?? string.Empty,
+                        innerException: __ex,
+                        statusCode: __response.StatusCode)
+                    {
+                        ResponseBody = __content,
+                        ResponseHeaders = global::System.Linq.Enumerable.ToDictionary(
+                            __response.Headers,
+                            h => h.Key,
+                            h => h.Value),
+                    };
+                }
+            }
+            else
+            {
+                try
+                {
+                    __response.EnsureSuccessStatusCode();
+
+                    using var __content = await __response.Content.ReadAsStreamAsync(
+#if NET5_0_OR_GREATER
+                        cancellationToken
+#endif
+                    ).ConfigureAwait(false);
+
+                    return
+                        await global::System.Text.Json.JsonSerializer.DeserializeAsync(__content, typeof(global::System.Collections.Generic.IList<global::LangSmith.APIKeyGetResponse>), JsonSerializerContext).ConfigureAwait(false) as global::System.Collections.Generic.IList<global::LangSmith.APIKeyGetResponse> ??
+                        throw new global::System.InvalidOperationException("Response deserialization failed.");
+                }
+                catch (global::System.Exception __ex)
+                {
+                    throw new global::LangSmith.ApiException(
+                        message: __response.ReasonPhrase ?? string.Empty,
+                        innerException: __ex,
+                        statusCode: __response.StatusCode)
+                    {
+                        ResponseHeaders = global::System.Linq.Enumerable.ToDictionary(
+                            __response.Headers,
+                            h => h.Key,
+                            h => h.Value),
+                    };
+                }
+            }
+        }
+    }
+}

--- a/src/libs/LangSmith/openapi.yaml
+++ b/src/libs/LangSmith/openapi.yaml
@@ -1919,6 +1919,85 @@ paths:
         - ApiKey: [ ]
         - OrganizationId: [ ]
         - BearerAuth: [ ]
+  /api/v1/orgs/current/personal-access-tokens:
+    get:
+      tags:
+        - orgs
+      summary: List Org Personal Access Tokens
+      operationId: list_org_personal_access_tokens_api_v1_orgs_current_personal_access_tokens_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                title: Response List Org Personal Access Tokens Api V1 Orgs Current Personal Access Tokens Get
+                type: array
+                items:
+                  $ref: '#/components/schemas/APIKeyGetResponse'
+      security:
+        - ApiKey: [ ]
+        - OrganizationId: [ ]
+        - BearerAuth: [ ]
+    post:
+      tags:
+        - orgs
+      summary: Create Org Personal Access Token
+      operationId: create_org_personal_access_token_api_v1_orgs_current_personal_access_tokens_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/APIKeyCreateRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIKeyCreateResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - ApiKey: [ ]
+        - OrganizationId: [ ]
+        - BearerAuth: [ ]
+  '/api/v1/orgs/current/personal-access-tokens/{pat_id}':
+    delete:
+      tags:
+        - orgs
+      summary: Delete Org Personal Access Token
+      operationId: delete_org_personal_access_token_api_v1_orgs_current_personal_access_tokens__pat_id__delete
+      parameters:
+        - name: pat_id
+          in: path
+          required: true
+          schema:
+            title: Pat Id
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIKeyGetResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - ApiKey: [ ]
+        - OrganizationId: [ ]
+        - BearerAuth: [ ]
   /api/v1/login:
     post:
       tags:
@@ -18674,10 +18753,6 @@ components:
           title: New Rule Evaluator Creation Version
           type: integer
           default: 2
-        enable_tracing_project_redesign:
-          title: Enable Tracing Project Redesign
-          type: boolean
-          default: false
         org_scoped_service_accounts_enabled:
           title: Org Scoped Service Accounts Enabled
           type: boolean


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new API endpoints for managing personal access tokens within the current organization, including listing, creating, and deleting tokens.

* **Refactor**
  * Removed the "enable tracing project redesign" configuration option from organization settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->