### PR TITLE
feat:Add optional stats_start_time query param to sessions endpoints

### DIFF
--- a/src/libs/LangSmith/Generated/LangSmith.ITracerSessionsClient.ReadTracerSession.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.ITracerSessionsClient.ReadTracerSession.g.cs
@@ -12,12 +12,14 @@ namespace LangSmith
         /// <param name="includeStats">
         /// Default Value: false
         /// </param>
+        /// <param name="statsStartTime"></param>
         /// <param name="accept"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::LangSmith.ApiException"></exception>
         global::System.Threading.Tasks.Task<global::LangSmith.TracerSession> ReadTracerSessionAsync(
             global::System.Guid sessionId,
             bool? includeStats = default,
+            global::System.DateTime? statsStartTime = default,
             string? accept = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }

--- a/src/libs/LangSmith/Generated/LangSmith.ITracerSessionsClient.ReadTracerSessions.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.ITracerSessionsClient.ReadTracerSessions.g.cs
@@ -37,6 +37,7 @@ namespace LangSmith
         /// <param name="useApproxStats">
         /// Default Value: false
         /// </param>
+        /// <param name="statsStartTime"></param>
         /// <param name="accept"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::LangSmith.ApiException"></exception>
@@ -58,6 +59,7 @@ namespace LangSmith
             string? filter = default,
             bool? includeStats = default,
             bool? useApproxStats = default,
+            global::System.DateTime? statsStartTime = default,
             string? accept = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }

--- a/src/libs/LangSmith/Generated/LangSmith.TracerSessionsClient.ReadTracerSession.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.TracerSessionsClient.ReadTracerSession.g.cs
@@ -9,12 +9,14 @@ namespace LangSmith
             global::System.Net.Http.HttpClient httpClient,
             ref global::System.Guid sessionId,
             ref bool? includeStats,
+            ref global::System.DateTime? statsStartTime,
             ref string? accept);
         partial void PrepareReadTracerSessionRequest(
             global::System.Net.Http.HttpClient httpClient,
             global::System.Net.Http.HttpRequestMessage httpRequestMessage,
             global::System.Guid sessionId,
             bool? includeStats,
+            global::System.DateTime? statsStartTime,
             string? accept);
         partial void ProcessReadTracerSessionResponse(
             global::System.Net.Http.HttpClient httpClient,
@@ -33,12 +35,14 @@ namespace LangSmith
         /// <param name="includeStats">
         /// Default Value: false
         /// </param>
+        /// <param name="statsStartTime"></param>
         /// <param name="accept"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::LangSmith.ApiException"></exception>
         public async global::System.Threading.Tasks.Task<global::LangSmith.TracerSession> ReadTracerSessionAsync(
             global::System.Guid sessionId,
             bool? includeStats = default,
+            global::System.DateTime? statsStartTime = default,
             string? accept = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
@@ -48,6 +52,7 @@ namespace LangSmith
                 httpClient: HttpClient,
                 sessionId: ref sessionId,
                 includeStats: ref includeStats,
+                statsStartTime: ref statsStartTime,
                 accept: ref accept);
 
             var __pathBuilder = new global::LangSmith.PathBuilder(
@@ -55,6 +60,7 @@ namespace LangSmith
                 baseUri: HttpClient.BaseAddress); 
             __pathBuilder 
                 .AddOptionalParameter("include_stats", includeStats?.ToString()) 
+                .AddOptionalParameter("stats_start_time", statsStartTime?.ToString("yyyy-MM-ddTHH:mm:ssZ")) 
                 ; 
             var __path = __pathBuilder.ToString();
             using var __httpRequest = new global::System.Net.Http.HttpRequestMessage(
@@ -95,6 +101,7 @@ namespace LangSmith
                 httpRequestMessage: __httpRequest,
                 sessionId: sessionId,
                 includeStats: includeStats,
+                statsStartTime: statsStartTime,
                 accept: accept);
 
             using var __response = await HttpClient.SendAsync(

--- a/src/libs/LangSmith/Generated/LangSmith.TracerSessionsClient.ReadTracerSessions.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.TracerSessionsClient.ReadTracerSessions.g.cs
@@ -24,6 +24,7 @@ namespace LangSmith
             ref string? filter,
             ref bool? includeStats,
             ref bool? useApproxStats,
+            ref global::System.DateTime? statsStartTime,
             ref string? accept);
         partial void PrepareReadTracerSessionsRequest(
             global::System.Net.Http.HttpClient httpClient,
@@ -45,6 +46,7 @@ namespace LangSmith
             string? filter,
             bool? includeStats,
             bool? useApproxStats,
+            global::System.DateTime? statsStartTime,
             string? accept);
         partial void ProcessReadTracerSessionsResponse(
             global::System.Net.Http.HttpClient httpClient,
@@ -88,6 +90,7 @@ namespace LangSmith
         /// <param name="useApproxStats">
         /// Default Value: false
         /// </param>
+        /// <param name="statsStartTime"></param>
         /// <param name="accept"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::LangSmith.ApiException"></exception>
@@ -109,6 +112,7 @@ namespace LangSmith
             string? filter = default,
             bool? includeStats = default,
             bool? useApproxStats = default,
+            global::System.DateTime? statsStartTime = default,
             string? accept = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
@@ -133,6 +137,7 @@ namespace LangSmith
                 filter: ref filter,
                 includeStats: ref includeStats,
                 useApproxStats: ref useApproxStats,
+                statsStartTime: ref statsStartTime,
                 accept: ref accept);
 
             var __pathBuilder = new global::LangSmith.PathBuilder(
@@ -156,6 +161,7 @@ namespace LangSmith
                 .AddOptionalParameter("filter", filter) 
                 .AddOptionalParameter("include_stats", includeStats?.ToString()) 
                 .AddOptionalParameter("use_approx_stats", useApproxStats?.ToString()) 
+                .AddOptionalParameter("stats_start_time", statsStartTime?.ToString("yyyy-MM-ddTHH:mm:ssZ")) 
                 ; 
             var __path = __pathBuilder.ToString();
             using var __httpRequest = new global::System.Net.Http.HttpRequestMessage(
@@ -211,6 +217,7 @@ namespace LangSmith
                 filter: filter,
                 includeStats: includeStats,
                 useApproxStats: useApproxStats,
+                statsStartTime: statsStartTime,
                 accept: accept);
 
             using var __response = await HttpClient.SendAsync(

--- a/src/libs/LangSmith/openapi.yaml
+++ b/src/libs/LangSmith/openapi.yaml
@@ -70,6 +70,13 @@ paths:
             title: Include Stats
             type: boolean
             default: false
+        - name: stats_start_time
+          in: query
+          schema:
+            title: Stats Start Time
+            type: string
+            format: date-time
+            nullable: true
         - name: accept
           in: header
           schema:
@@ -280,6 +287,13 @@ paths:
             title: Use Approx Stats
             type: boolean
             default: false
+        - name: stats_start_time
+          in: query
+          schema:
+            title: Stats Start Time
+            type: string
+            format: date-time
+            nullable: true
         - name: accept
           in: header
           schema:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional stats_start_time (ISO 8601 date-time) query parameter to GET /api/v1/sessions and GET /api/v1/sessions/{session_id}, enabling you to scope returned statistics from a specified start time.
  * Helps analyze trends from a chosen point without affecting existing behavior. The parameter is nullable and backward-compatible; existing requests and defaults remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->