### PR TITLE
feat:Add boolean can_use_agent_auth to OrganizationConfig in OpenAPI

### DIFF
--- a/src/libs/LangSmith/Generated/LangSmith.Models.OrganizationConfig.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.OrganizationConfig.g.cs
@@ -69,6 +69,12 @@ namespace LangSmith
         public bool? CanUseLanggraphCloud { get; set; }
 
         /// <summary>
+        /// Default Value: false
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("can_use_agent_auth")]
+        public bool? CanUseAgentAuth { get; set; }
+
+        /// <summary>
         /// Default Value: 3
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("max_langgraph_cloud_deployments")]
@@ -323,6 +329,9 @@ namespace LangSmith
         /// <param name="canUseLanggraphCloud">
         /// Default Value: false
         /// </param>
+        /// <param name="canUseAgentAuth">
+        /// Default Value: false
+        /// </param>
         /// <param name="maxLanggraphCloudDeployments">
         /// Default Value: 3
         /// </param>
@@ -448,6 +457,7 @@ namespace LangSmith
             bool? canDisablePublicSharing,
             bool? canServeDatasets,
             bool? canUseLanggraphCloud,
+            bool? canUseAgentAuth,
             int? maxLanggraphCloudDeployments,
             int? maxFreeLanggraphCloudDeployments,
             bool? canUseSamlSso,
@@ -496,6 +506,7 @@ namespace LangSmith
             this.CanDisablePublicSharing = canDisablePublicSharing;
             this.CanServeDatasets = canServeDatasets;
             this.CanUseLanggraphCloud = canUseLanggraphCloud;
+            this.CanUseAgentAuth = canUseAgentAuth;
             this.MaxLanggraphCloudDeployments = maxLanggraphCloudDeployments;
             this.MaxFreeLanggraphCloudDeployments = maxFreeLanggraphCloudDeployments;
             this.CanUseSamlSso = canUseSamlSso;

--- a/src/libs/LangSmith/openapi.yaml
+++ b/src/libs/LangSmith/openapi.yaml
@@ -19193,6 +19193,10 @@ components:
           title: Can Use Langgraph Cloud
           type: boolean
           default: false
+        can_use_agent_auth:
+          title: Can Use Agent Auth
+          type: boolean
+          default: false
         max_langgraph_cloud_deployments:
           title: Max Langgraph Cloud Deployments
           type: integer


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a new organization configuration setting: can_use_agent_auth (boolean). It appears in API requests/responses for organization configuration and defaults to false to preserve current behavior.
  - Backward compatible: existing configurations remain unchanged; the field is optional and will be false unless explicitly set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->