### PR TITLE
feat:Add optional attribute_schemas to CreateRunClusteringJobRequest

### DIFF
--- a/src/libs/LangSmith/Generated/LangSmith.ITracerSessionsClient.[Beta]CreateInsightsJob.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.ITracerSessionsClient.[Beta]CreateInsightsJob.g.cs
@@ -31,6 +31,7 @@ namespace LangSmith
         /// <param name="summaryPrompt"></param>
         /// <param name="filter"></param>
         /// <param name="name"></param>
+        /// <param name="attributeSchemas"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         global::System.Threading.Tasks.Task<global::LangSmith.CreateRunClusteringJobResponse> [Beta]CreateInsightsJobAsync(
@@ -44,6 +45,7 @@ namespace LangSmith
             string? summaryPrompt = default,
             string? filter = default,
             string? name = default,
+            object? attributeSchemas = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }
 }

--- a/src/libs/LangSmith/Generated/LangSmith.Models.CreateRunClusteringJobRequest.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.CreateRunClusteringJobRequest.g.cs
@@ -66,6 +66,12 @@ namespace LangSmith
         public string? Name { get; set; }
 
         /// <summary>
+        /// 
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("attribute_schemas")]
+        public object? AttributeSchemas { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -83,6 +89,7 @@ namespace LangSmith
         /// <param name="summaryPrompt"></param>
         /// <param name="filter"></param>
         /// <param name="name"></param>
+        /// <param name="attributeSchemas"></param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
@@ -95,7 +102,8 @@ namespace LangSmith
             global::LangSmith.AnyOf<double?, int?>? sample,
             string? summaryPrompt,
             string? filter,
-            string? name)
+            string? name,
+            object? attributeSchemas)
         {
             this.StartTime = startTime;
             this.EndTime = endTime;
@@ -106,6 +114,7 @@ namespace LangSmith
             this.SummaryPrompt = summaryPrompt;
             this.Filter = filter;
             this.Name = name;
+            this.AttributeSchemas = attributeSchemas;
         }
 
         /// <summary>

--- a/src/libs/LangSmith/Generated/LangSmith.Models.CreateRunClusteringJobRequestAttributeSchemas.Json.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.CreateRunClusteringJobRequestAttributeSchemas.Json.g.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+namespace LangSmith
+{
+    public sealed partial class CreateRunClusteringJobRequestAttributeSchemas
+    {
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public string ToJson(
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                this.GetType(),
+                jsonSerializerContext);
+        }
+
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public string ToJson(
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public static global::LangSmith.CreateRunClusteringJobRequestAttributeSchemas? FromJson(
+            string json,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize(
+                json,
+                typeof(global::LangSmith.CreateRunClusteringJobRequestAttributeSchemas),
+                jsonSerializerContext) as global::LangSmith.CreateRunClusteringJobRequestAttributeSchemas;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::LangSmith.CreateRunClusteringJobRequestAttributeSchemas? FromJson(
+            string json,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::LangSmith.CreateRunClusteringJobRequestAttributeSchemas>(
+                json,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerContext.
+        /// </summary>
+        public static async global::System.Threading.Tasks.ValueTask<global::LangSmith.CreateRunClusteringJobRequestAttributeSchemas?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
+                jsonStream,
+                typeof(global::LangSmith.CreateRunClusteringJobRequestAttributeSchemas),
+                jsonSerializerContext).ConfigureAwait(false)) as global::LangSmith.CreateRunClusteringJobRequestAttributeSchemas;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::System.Threading.Tasks.ValueTask<global::LangSmith.CreateRunClusteringJobRequestAttributeSchemas?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::LangSmith.CreateRunClusteringJobRequestAttributeSchemas?>(
+                jsonStream,
+                jsonSerializerOptions);
+        }
+    }
+}

--- a/src/libs/LangSmith/Generated/LangSmith.Models.CreateRunClusteringJobRequestAttributeSchemas.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.CreateRunClusteringJobRequestAttributeSchemas.g.cs
@@ -1,0 +1,18 @@
+
+#nullable enable
+
+namespace LangSmith
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public sealed partial class CreateRunClusteringJobRequestAttributeSchemas
+    {
+
+        /// <summary>
+        /// Additional properties that are not explicitly defined in the schema
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonExtensionData]
+        public global::System.Collections.Generic.IDictionary<string, object> AdditionalProperties { get; set; } = new global::System.Collections.Generic.Dictionary<string, object>();
+    }
+}

--- a/src/libs/LangSmith/Generated/LangSmith.TracerSessionsClient.[Beta]CreateInsightsJob.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.TracerSessionsClient.[Beta]CreateInsightsJob.g.cs
@@ -223,6 +223,7 @@ namespace LangSmith
         /// <param name="summaryPrompt"></param>
         /// <param name="filter"></param>
         /// <param name="name"></param>
+        /// <param name="attributeSchemas"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         public async global::System.Threading.Tasks.Task<global::LangSmith.CreateRunClusteringJobResponse> [Beta]CreateInsightsJobAsync(
@@ -236,6 +237,7 @@ namespace LangSmith
             string? summaryPrompt = default,
             string? filter = default,
             string? name = default,
+            object? attributeSchemas = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             var __request = new global::LangSmith.CreateRunClusteringJobRequest
@@ -249,6 +251,7 @@ namespace LangSmith
                 SummaryPrompt = summaryPrompt,
                 Filter = filter,
                 Name = name,
+                AttributeSchemas = attributeSchemas,
             };
 
             return await [Beta]CreateInsightsJobAsync(

--- a/src/libs/LangSmith/openapi.yaml
+++ b/src/libs/LangSmith/openapi.yaml
@@ -15766,6 +15766,10 @@ components:
           title: Name
           type: string
           nullable: true
+        attribute_schemas:
+          title: Attribute Schemas
+          type: object
+          nullable: true
       description: Request to create a run clustering job.
     CreateRunClusteringJobResponse:
       title: CreateRunClusteringJobResponse


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The clustering job creation request now supports an optional “attribute schemas” object for additional configuration.

* **Documentation**
  * OpenAPI specification updated to include the new optional “attribute schemas” field in the clustering job creation request.

* **Chores**
  * No changes to endpoints or responses; only the request schema was extended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->