### PR TITLE
feat:OpenAPI: Add POST default SSO, default_sso_provision; extend enums

### DIFF
--- a/src/libs/LangSmith/Generated/LangSmith.IOrgsClient.SetDefaultSsoProvision.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.IOrgsClient.SetDefaultSsoProvision.g.cs
@@ -1,0 +1,16 @@
+#nullable enable
+
+namespace LangSmith
+{
+    public partial interface IOrgsClient
+    {
+        /// <summary>
+        /// Set Default Sso Provision<br/>
+        /// Set the current organization as the default for SSO provisioning in self-hosted environments.
+        /// </summary>
+        /// <param name="cancellationToken">The token to cancel the operation with</param>
+        /// <exception cref="global::LangSmith.ApiException"></exception>
+        global::System.Threading.Tasks.Task<string> SetDefaultSsoProvisionAsync(
+            global::System.Threading.CancellationToken cancellationToken = default);
+    }
+}

--- a/src/libs/LangSmith/Generated/LangSmith.Models.Organization.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.Organization.g.cs
@@ -111,6 +111,12 @@ namespace LangSmith
         public global::LangSmith.Wallet? Wallet { get; set; }
 
         /// <summary>
+        /// Default Value: false
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("default_sso_provision")]
+        public bool? DefaultSsoProvision { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -147,6 +153,9 @@ namespace LangSmith
         /// Default Value: false
         /// </param>
         /// <param name="wallet"></param>
+        /// <param name="defaultSsoProvision">
+        /// Default Value: false
+        /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
@@ -166,7 +175,8 @@ namespace LangSmith
             bool? reachedMaxWorkspaces,
             global::System.Collections.Generic.IList<string>? permissions,
             bool? marketplacePayoutsEnabled,
-            global::LangSmith.Wallet? wallet)
+            global::LangSmith.Wallet? wallet,
+            bool? defaultSsoProvision)
         {
             this.Config = config ?? throw new global::System.ArgumentNullException(nameof(config));
             this.ConnectedToStripe = connectedToStripe;
@@ -184,6 +194,7 @@ namespace LangSmith
             this.Permissions = permissions;
             this.MarketplacePayoutsEnabled = marketplacePayoutsEnabled;
             this.Wallet = wallet;
+            this.DefaultSsoProvision = defaultSsoProvision;
         }
 
         /// <summary>

--- a/src/libs/LangSmith/Generated/LangSmith.Models.OrganizationBillingInfo.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.OrganizationBillingInfo.g.cs
@@ -93,6 +93,12 @@ namespace LangSmith
         public bool? Disabled { get; set; }
 
         /// <summary>
+        /// Default Value: false
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("default_sso_provision")]
+        public bool? DefaultSsoProvision { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -126,6 +132,9 @@ namespace LangSmith
         /// <param name="disabled">
         /// Default Value: false
         /// </param>
+        /// <param name="defaultSsoProvision">
+        /// Default Value: false
+        /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
@@ -142,7 +151,8 @@ namespace LangSmith
             global::LangSmith.CustomerVisiblePlanInfo? currentPlan,
             global::LangSmith.CustomerVisiblePlanInfo? upcomingPlan,
             bool? reachedMaxWorkspaces,
-            bool? disabled)
+            bool? disabled,
+            bool? defaultSsoProvision)
         {
             this.DisplayName = displayName ?? throw new global::System.ArgumentNullException(nameof(displayName));
             this.Config = config ?? throw new global::System.ArgumentNullException(nameof(config));
@@ -157,6 +167,7 @@ namespace LangSmith
             this.UpcomingPlan = upcomingPlan;
             this.ReachedMaxWorkspaces = reachedMaxWorkspaces;
             this.Disabled = disabled;
+            this.DefaultSsoProvision = defaultSsoProvision;
         }
 
         /// <summary>

--- a/src/libs/LangSmith/Generated/LangSmith.Models.OrganizationInfo.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.OrganizationInfo.g.cs
@@ -96,6 +96,12 @@ namespace LangSmith
         public global::LangSmith.Wallet? Wallet { get; set; }
 
         /// <summary>
+        /// Default Value: false
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("default_sso_provision")]
+        public bool? DefaultSsoProvision { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -132,6 +138,9 @@ namespace LangSmith
         /// Default Value: false
         /// </param>
         /// <param name="wallet"></param>
+        /// <param name="defaultSsoProvision">
+        /// Default Value: false
+        /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
@@ -149,7 +158,8 @@ namespace LangSmith
             string? ssoLoginSlug,
             bool? publicSharingDisabled,
             bool? marketplacePayoutsEnabled,
-            global::LangSmith.Wallet? wallet)
+            global::LangSmith.Wallet? wallet,
+            bool? defaultSsoProvision)
         {
             this.Config = config ?? throw new global::System.ArgumentNullException(nameof(config));
             this.IsPersonal = isPersonal;
@@ -165,6 +175,7 @@ namespace LangSmith
             this.PublicSharingDisabled = publicSharingDisabled;
             this.MarketplacePayoutsEnabled = marketplacePayoutsEnabled;
             this.Wallet = wallet;
+            this.DefaultSsoProvision = defaultSsoProvision;
         }
 
         /// <summary>

--- a/src/libs/LangSmith/Generated/LangSmith.Models.OrganizationPGSchemaSlim.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.OrganizationPGSchemaSlim.g.cs
@@ -85,6 +85,12 @@ namespace LangSmith
         public bool? PublicSharingDisabled { get; set; }
 
         /// <summary>
+        /// Default Value: false
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("default_sso_provision")]
+        public bool? DefaultSsoProvision { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -111,6 +117,9 @@ namespace LangSmith
         /// <param name="publicSharingDisabled">
         /// Default Value: false
         /// </param>
+        /// <param name="defaultSsoProvision">
+        /// Default Value: false
+        /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
@@ -126,7 +135,8 @@ namespace LangSmith
             string? ssoLoginSlug,
             bool? ssoOnly,
             bool? jitProvisioningEnabled,
-            bool? publicSharingDisabled)
+            bool? publicSharingDisabled,
+            bool? defaultSsoProvision)
         {
             this.Id = id;
             this.DisplayName = displayName ?? throw new global::System.ArgumentNullException(nameof(displayName));
@@ -140,6 +150,7 @@ namespace LangSmith
             this.SsoOnly = ssoOnly;
             this.JitProvisioningEnabled = jitProvisioningEnabled;
             this.PublicSharingDisabled = publicSharingDisabled;
+            this.DefaultSsoProvision = defaultSsoProvision;
         }
 
         /// <summary>

--- a/src/libs/LangSmith/Generated/LangSmith.Models.ProvisioningMethod.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.ProvisioningMethod.g.cs
@@ -16,6 +16,10 @@ namespace LangSmith
         /// 
         /// </summary>
         Saml_jit,
+        /// <summary>
+        /// 
+        /// </summary>
+        Bootstrap,
     }
 
     /// <summary>
@@ -32,6 +36,7 @@ namespace LangSmith
             {
                 ProvisioningMethod.Scim => "scim",
                 ProvisioningMethod.Saml_jit => "saml:jit",
+                ProvisioningMethod.Bootstrap => "bootstrap",
                 _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
             };
         }
@@ -44,6 +49,7 @@ namespace LangSmith
             {
                 "scim" => ProvisioningMethod.Scim,
                 "saml:jit" => ProvisioningMethod.Saml_jit,
+                "bootstrap" => ProvisioningMethod.Bootstrap,
                 _ => null,
             };
         }

--- a/src/libs/LangSmith/Generated/LangSmith.Models.SetDefaultSsoProvisionApiV1OrgsCurrentSetDefaultSsoProvisionPostResponse.Json.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.SetDefaultSsoProvisionApiV1OrgsCurrentSetDefaultSsoProvisionPostResponse.Json.g.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+namespace LangSmith
+{
+    public sealed partial class SetDefaultSsoProvisionApiV1OrgsCurrentSetDefaultSsoProvisionPostResponse
+    {
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public string ToJson(
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                this.GetType(),
+                jsonSerializerContext);
+        }
+
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public string ToJson(
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public static global::LangSmith.SetDefaultSsoProvisionApiV1OrgsCurrentSetDefaultSsoProvisionPostResponse? FromJson(
+            string json,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize(
+                json,
+                typeof(global::LangSmith.SetDefaultSsoProvisionApiV1OrgsCurrentSetDefaultSsoProvisionPostResponse),
+                jsonSerializerContext) as global::LangSmith.SetDefaultSsoProvisionApiV1OrgsCurrentSetDefaultSsoProvisionPostResponse;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::LangSmith.SetDefaultSsoProvisionApiV1OrgsCurrentSetDefaultSsoProvisionPostResponse? FromJson(
+            string json,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::LangSmith.SetDefaultSsoProvisionApiV1OrgsCurrentSetDefaultSsoProvisionPostResponse>(
+                json,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerContext.
+        /// </summary>
+        public static async global::System.Threading.Tasks.ValueTask<global::LangSmith.SetDefaultSsoProvisionApiV1OrgsCurrentSetDefaultSsoProvisionPostResponse?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
+                jsonStream,
+                typeof(global::LangSmith.SetDefaultSsoProvisionApiV1OrgsCurrentSetDefaultSsoProvisionPostResponse),
+                jsonSerializerContext).ConfigureAwait(false)) as global::LangSmith.SetDefaultSsoProvisionApiV1OrgsCurrentSetDefaultSsoProvisionPostResponse;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::System.Threading.Tasks.ValueTask<global::LangSmith.SetDefaultSsoProvisionApiV1OrgsCurrentSetDefaultSsoProvisionPostResponse?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::LangSmith.SetDefaultSsoProvisionApiV1OrgsCurrentSetDefaultSsoProvisionPostResponse?>(
+                jsonStream,
+                jsonSerializerOptions);
+        }
+    }
+}

--- a/src/libs/LangSmith/Generated/LangSmith.Models.SetDefaultSsoProvisionApiV1OrgsCurrentSetDefaultSsoProvisionPostResponse.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.Models.SetDefaultSsoProvisionApiV1OrgsCurrentSetDefaultSsoProvisionPostResponse.g.cs
@@ -1,0 +1,18 @@
+
+#nullable enable
+
+namespace LangSmith
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public sealed partial class SetDefaultSsoProvisionApiV1OrgsCurrentSetDefaultSsoProvisionPostResponse
+    {
+
+        /// <summary>
+        /// Additional properties that are not explicitly defined in the schema
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonExtensionData]
+        public global::System.Collections.Generic.IDictionary<string, object> AdditionalProperties { get; set; } = new global::System.Collections.Generic.Dictionary<string, object>();
+    }
+}

--- a/src/libs/LangSmith/Generated/LangSmith.OrgsClient.SetDefaultSsoProvision.g.cs
+++ b/src/libs/LangSmith/Generated/LangSmith.OrgsClient.SetDefaultSsoProvision.g.cs
@@ -1,0 +1,151 @@
+
+#nullable enable
+
+namespace LangSmith
+{
+    public partial class OrgsClient
+    {
+        partial void PrepareSetDefaultSsoProvisionArguments(
+            global::System.Net.Http.HttpClient httpClient);
+        partial void PrepareSetDefaultSsoProvisionRequest(
+            global::System.Net.Http.HttpClient httpClient,
+            global::System.Net.Http.HttpRequestMessage httpRequestMessage);
+        partial void ProcessSetDefaultSsoProvisionResponse(
+            global::System.Net.Http.HttpClient httpClient,
+            global::System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+        partial void ProcessSetDefaultSsoProvisionResponseContent(
+            global::System.Net.Http.HttpClient httpClient,
+            global::System.Net.Http.HttpResponseMessage httpResponseMessage,
+            ref string content);
+
+        /// <summary>
+        /// Set Default Sso Provision<br/>
+        /// Set the current organization as the default for SSO provisioning in self-hosted environments.
+        /// </summary>
+        /// <param name="cancellationToken">The token to cancel the operation with</param>
+        /// <exception cref="global::LangSmith.ApiException"></exception>
+        public async global::System.Threading.Tasks.Task<string> SetDefaultSsoProvisionAsync(
+            global::System.Threading.CancellationToken cancellationToken = default)
+        {
+            PrepareArguments(
+                client: HttpClient);
+            PrepareSetDefaultSsoProvisionArguments(
+                httpClient: HttpClient);
+
+            var __pathBuilder = new global::LangSmith.PathBuilder(
+                path: "/api/v1/orgs/current/set-default-sso-provision",
+                baseUri: HttpClient.BaseAddress); 
+            var __path = __pathBuilder.ToString();
+            using var __httpRequest = new global::System.Net.Http.HttpRequestMessage(
+                method: global::System.Net.Http.HttpMethod.Post,
+                requestUri: new global::System.Uri(__path, global::System.UriKind.RelativeOrAbsolute));
+#if NET6_0_OR_GREATER
+            __httpRequest.Version = global::System.Net.HttpVersion.Version11;
+            __httpRequest.VersionPolicy = global::System.Net.Http.HttpVersionPolicy.RequestVersionOrHigher;
+#endif
+
+            foreach (var __authorization in Authorizations)
+            {
+                if (__authorization.Type == "Http" ||
+                    __authorization.Type == "OAuth2")
+                {
+                    __httpRequest.Headers.Authorization = new global::System.Net.Http.Headers.AuthenticationHeaderValue(
+                        scheme: __authorization.Name,
+                        parameter: __authorization.Value);
+                }
+                else if (__authorization.Type == "ApiKey" &&
+                         __authorization.Location == "Header")
+                {
+                    __httpRequest.Headers.Add(__authorization.Name, __authorization.Value);
+                }
+            }
+
+            PrepareRequest(
+                client: HttpClient,
+                request: __httpRequest);
+            PrepareSetDefaultSsoProvisionRequest(
+                httpClient: HttpClient,
+                httpRequestMessage: __httpRequest);
+
+            using var __response = await HttpClient.SendAsync(
+                request: __httpRequest,
+                completionOption: global::System.Net.Http.HttpCompletionOption.ResponseContentRead,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            ProcessResponse(
+                client: HttpClient,
+                response: __response);
+            ProcessSetDefaultSsoProvisionResponse(
+                httpClient: HttpClient,
+                httpResponseMessage: __response);
+
+            if (ReadResponseAsString)
+            {
+                var __content = await __response.Content.ReadAsStringAsync(
+#if NET5_0_OR_GREATER
+                    cancellationToken
+#endif
+                ).ConfigureAwait(false);
+
+                ProcessResponseContent(
+                    client: HttpClient,
+                    response: __response,
+                    content: ref __content);
+                ProcessSetDefaultSsoProvisionResponseContent(
+                    httpClient: HttpClient,
+                    httpResponseMessage: __response,
+                    content: ref __content);
+
+                try
+                {
+                    __response.EnsureSuccessStatusCode();
+
+                    return __content;
+                }
+                catch (global::System.Exception __ex)
+                {
+                    throw new global::LangSmith.ApiException(
+                        message: __content ?? __response.ReasonPhrase ?? string.Empty,
+                        innerException: __ex,
+                        statusCode: __response.StatusCode)
+                    {
+                        ResponseBody = __content,
+                        ResponseHeaders = global::System.Linq.Enumerable.ToDictionary(
+                            __response.Headers,
+                            h => h.Key,
+                            h => h.Value),
+                    };
+                }
+            }
+            else
+            {
+                try
+                {
+                    __response.EnsureSuccessStatusCode();
+
+                    var __content = await __response.Content.ReadAsStringAsync(
+#if NET5_0_OR_GREATER
+                        cancellationToken
+#endif
+                    ).ConfigureAwait(false);
+
+                    return __content;
+                }
+                catch (global::System.Exception __ex)
+                {
+                    throw new global::LangSmith.ApiException(
+                        message: __response.ReasonPhrase ?? string.Empty,
+                        innerException: __ex,
+                        statusCode: __response.StatusCode)
+                    {
+                        ResponseHeaders = global::System.Linq.Enumerable.ToDictionary(
+                            __response.Headers,
+                            h => h.Key,
+                            h => h.Value),
+                    };
+                }
+            }
+        }
+    }
+}

--- a/src/libs/LangSmith/openapi.yaml
+++ b/src/libs/LangSmith/openapi.yaml
@@ -2326,6 +2326,25 @@ paths:
         - ApiKey: [ ]
         - OrganizationId: [ ]
         - BearerAuth: [ ]
+  /api/v1/orgs/current/set-default-sso-provision:
+    post:
+      tags:
+        - orgs
+      summary: Set Default Sso Provision
+      description: Set the current organization as the default for SSO provisioning in self-hosted environments.
+      operationId: set_default_sso_provision_api_v1_orgs_current_set_default_sso_provision_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                title: Response Set Default Sso Provision Api V1 Orgs Current Set Default Sso Provision Post
+                type: object
+      security:
+        - ApiKey: [ ]
+        - OrganizationId: [ ]
+        - BearerAuth: [ ]
   /api/v1/login:
     post:
       tags:
@@ -19438,6 +19457,10 @@ components:
           default: false
         wallet:
           $ref: '#/components/schemas/Wallet'
+        default_sso_provision:
+          title: Default Sso Provision
+          type: boolean
+          default: false
       description: Information about an organization.
     OrganizationBillingInfo:
       title: OrganizationBillingInfo
@@ -19487,6 +19510,10 @@ components:
           default: false
         disabled:
           title: Disabled
+          type: boolean
+          default: false
+        default_sso_provision:
+          title: Default Sso Provision
           type: boolean
           default: false
       description: Information about an organization's billing configuration.
@@ -19779,6 +19806,10 @@ components:
           default: false
         wallet:
           $ref: '#/components/schemas/Wallet'
+        default_sso_provision:
+          title: Default Sso Provision
+          type: boolean
+          default: false
       description: Information about an organization.
     OrganizationMembers:
       title: OrganizationMembers
@@ -19859,6 +19890,10 @@ components:
           default: true
         public_sharing_disabled:
           title: Public Sharing Disabled
+          type: boolean
+          default: false
+        default_sso_provision:
+          title: Default Sso Provision
           type: boolean
           default: false
       description: Schema for an organization in postgres for list views.
@@ -20912,6 +20947,7 @@ components:
       enum:
         - scim
         - saml:jit
+        - bootstrap
       type: string
     PublicComparativeExperiment:
       title: PublicComparativeExperiment


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Set your organization as the default for SSO provisioning in self-hosted deployments.
  * New default_sso_provision setting appears in organization details and billing info.
  * Added a “bootstrap” option for prompt optimization and provisioning workflows.

* **API**
  * New endpoint to set the default SSO provision for the current organization.
  * Organization-related responses now include a default_sso_provision boolean field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->